### PR TITLE
fixed gc of notifications during logout

### DIFF
--- a/front/src/actions/notifications.js
+++ b/front/src/actions/notifications.js
@@ -2,9 +2,9 @@ import { FoxApiService } from '../services'
 
 const foxApi = new FoxApiService();
 
-const getNotifications = () => {
+const getNotifications = ({ signal = null }) => {
   return dispatch => {
-    foxApi.getEntityList('notifications')
+    foxApi.getEntityList('notifications', null, signal)
       .then(data => {
         if (data.length > 0) {
           dispatch(refreshNotificationList(data))

--- a/front/src/components/badges/NotificationCountBadge.js
+++ b/front/src/components/badges/NotificationCountBadge.js
@@ -6,7 +6,7 @@ import {
 
 
 const NotificationCountBadge = props => {
-  const unreadNotificationsCount = props.items.filter(item => item.unread).length
+  const unreadNotificationsCount = props.item ? props.items.filter(item => item.unread).length : 0
   return (
     <React.Fragment>
       <CIcon name="cil-bell" />

--- a/front/src/components/layout/FoxHeaderDropdownMssg.js
+++ b/front/src/components/layout/FoxHeaderDropdownMssg.js
@@ -8,7 +8,7 @@ import {
   CImg
 } from '@coreui/react'
 import { NotificationCountBadge } from '../badges'
-import { getNotifications } from '../../actions'
+import { clearNotifications, getNotifications } from '../../actions'
 import { NotificationMessage } from '../../utils'
 
 class TheHeaderDropdownMssg extends Component {
@@ -18,15 +18,19 @@ class TheHeaderDropdownMssg extends Component {
   }
 
   componentDidMount = () => {
-    this.props.getNotifications()
+    this.props.getNotifications({ signal: this.abortController.signal })
     const timer = setInterval(this.props.getNotifications, 60000)
     this.setState({
       timer: timer
     })
   }
 
+  abortController = new window.AbortController();
+
   componentWillUnmount = () => {
-    clearInterval(this.state.timer)
+    this.abortController.abort();
+    clearInterval(this.state.timer);
+    this.props.clearNotifications()
   }
 
   render = () => {
@@ -65,7 +69,8 @@ const mapStateToProps = state => ({
 )
 
 const mapDispatchToProps = dispatch => ({
-  getNotifications: () => dispatch(getNotifications())
+  getNotifications: ({ ...kwargs }) => dispatch(getNotifications({ ...kwargs })),
+  clearNotifications: () => dispatch(clearNotifications())
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(TheHeaderDropdownMssg)


### PR DESCRIPTION
1. Added signal for aborting notifications fetching on dashboard unmount
2.  Corrected notification badge counter to work with undefined nnotification attribute in store.